### PR TITLE
feat : 장바구니 메뉴 추가 기능

### DIFF
--- a/src/main/java/com/example/toanyone/domain/cart/controller/CartController.java
+++ b/src/main/java/com/example/toanyone/domain/cart/controller/CartController.java
@@ -1,5 +1,38 @@
 package com.example.toanyone.domain.cart.controller;
 
+
+import com.example.toanyone.domain.cart.dto.CartRequestDto;
+import com.example.toanyone.domain.cart.dto.CartResponseDto;
+import com.example.toanyone.domain.cart.service.CartService;
+import com.example.toanyone.global.common.annotation.Auth;
+import com.example.toanyone.global.common.dto.AuthUser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/carts")
 public class CartController {
+
+    public final CartService cartService;
+
+    @PostMapping
+    public ResponseEntity<CartResponseDto> createCart(
+            @Auth AuthUser authUser, @RequestBody CartRequestDto cartRequestDto) {
+
+        CartResponseDto cartResponseDto = cartService.createCart(
+                authUser ,cartRequestDto.getStoreId(), cartRequestDto.getMenuId(), cartRequestDto.getQuantity()
+        );
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(cartResponseDto);
+    }
 
 }

--- a/src/main/java/com/example/toanyone/domain/cart/dto/CartRequestDto.java
+++ b/src/main/java/com/example/toanyone/domain/cart/dto/CartRequestDto.java
@@ -1,12 +1,16 @@
 package com.example.toanyone.domain.cart.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 public class CartRequestDto {
+
+    @NotBlank(message = "가게 ID 입력은 필수입니다")
+    private Long storeId;
 
     @NotBlank(message = "메뉴 ID 입력은 필수입니다")
     private Long menuId;

--- a/src/main/java/com/example/toanyone/domain/cart/dto/CartRequestDto.java
+++ b/src/main/java/com/example/toanyone/domain/cart/dto/CartRequestDto.java
@@ -1,6 +1,7 @@
 package com.example.toanyone.domain.cart.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,13 +10,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class CartRequestDto {
 
-    @NotBlank(message = "가게 ID 입력은 필수입니다")
+    @NotNull(message = "가게 ID 입력은 필수입니다")
     private Long storeId;
 
-    @NotBlank(message = "메뉴 ID 입력은 필수입니다")
+    @NotNull(message = "메뉴 ID 입력은 필수입니다")
     private Long menuId;
 
-    @NotBlank(message = "메뉴 수량 입력은 필수입니다")
+    @NotNull(message = "메뉴 수량 입력은 필수입니다")
     private Integer quantity;
 
 }

--- a/src/main/java/com/example/toanyone/domain/cart/dto/CartResponseDto.java
+++ b/src/main/java/com/example/toanyone/domain/cart/dto/CartResponseDto.java
@@ -1,5 +1,6 @@
 package com.example.toanyone.domain.cart.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -7,6 +8,8 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class CartResponseDto {
+    private String message;
 
 }

--- a/src/main/java/com/example/toanyone/domain/cart/entity/Cart.java
+++ b/src/main/java/com/example/toanyone/domain/cart/entity/Cart.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Entity
@@ -18,7 +20,7 @@ public class Cart {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
@@ -30,5 +32,19 @@ public class Cart {
 
     @Column(updatable = false)
     private LocalDateTime createdAt = LocalDateTime.now();
+
+    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CartItem> cartItems = new ArrayList<>();
+
+
+    public Cart(User user, Store store, Integer totalPrice){
+        this.user = user;
+        this.store = store;
+        this.totalPrice = totalPrice;
+    }
+
+    public void setTotalPrice(Integer price, Integer quantity) {
+        this.totalPrice += price * quantity;
+    }
 
 }

--- a/src/main/java/com/example/toanyone/domain/cart/entity/CartItem.java
+++ b/src/main/java/com/example/toanyone/domain/cart/entity/CartItem.java
@@ -28,4 +28,10 @@ public class CartItem {
     @Column(nullable = false)
     private Integer menu_price;
 
+    public CartItem(Cart cart, Menu menu, Integer quantity, Integer menu_price) {
+        this.cart = cart;
+        this.menu = menu;
+        this.quantity = quantity;
+        this.menu_price = menu_price;
+    }
 }

--- a/src/main/java/com/example/toanyone/domain/cart/repository/CartItemRepository.java
+++ b/src/main/java/com/example/toanyone/domain/cart/repository/CartItemRepository.java
@@ -1,0 +1,9 @@
+package com.example.toanyone.domain.cart.repository;
+
+import com.example.toanyone.domain.cart.entity.CartItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+}

--- a/src/main/java/com/example/toanyone/domain/cart/repository/CartRepository.java
+++ b/src/main/java/com/example/toanyone/domain/cart/repository/CartRepository.java
@@ -1,9 +1,13 @@
 package com.example.toanyone.domain.cart.repository;
 
 import com.example.toanyone.domain.cart.entity.Cart;
+import com.example.toanyone.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CartRepository extends JpaRepository<Cart, Long> {
+    boolean existsByUserId(Long id);
+
+    Cart findByUser(User user);
 }

--- a/src/main/java/com/example/toanyone/domain/cart/service/CartService.java
+++ b/src/main/java/com/example/toanyone/domain/cart/service/CartService.java
@@ -1,5 +1,13 @@
 package com.example.toanyone.domain.cart.service;
 
+import com.example.toanyone.domain.cart.dto.CartResponseDto;
+
+import com.example.toanyone.global.common.dto.AuthUser;
+import org.springframework.stereotype.Service;
+
+@Service
 public interface CartService {
 
+    CartResponseDto createCart(AuthUser authUser,Long storeId, Long menuId, Integer quantity
+    );
 }

--- a/src/main/java/com/example/toanyone/domain/cart/service/CartServiceImpl.java
+++ b/src/main/java/com/example/toanyone/domain/cart/service/CartServiceImpl.java
@@ -1,5 +1,52 @@
 package com.example.toanyone.domain.cart.service;
 
-public class CartServiceImpl {
+import com.example.toanyone.domain.cart.dto.CartResponseDto;
+import com.example.toanyone.domain.cart.entity.Cart;
+import com.example.toanyone.domain.cart.entity.CartItem;
+import com.example.toanyone.domain.cart.repository.CartItemRepository;
+import com.example.toanyone.domain.cart.repository.CartRepository;
+import com.example.toanyone.domain.menu.entity.Menu;
+import com.example.toanyone.domain.menu.repository.MenuRepository;
+import com.example.toanyone.domain.store.entity.Store;
+import com.example.toanyone.domain.store.repository.StoreRepository;
+import com.example.toanyone.domain.user.entity.User;
+import com.example.toanyone.domain.user.repository.UserRepository;
+import com.example.toanyone.global.common.dto.AuthUser;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
 
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CartServiceImpl implements CartService {
+    private final CartRepository cartRepository;
+    private final StoreRepository storeRepository;
+    private final UserRepository userRepository;
+    private final MenuRepository menuRepository;
+    private final CartItemRepository cartItemRepository;
+
+    @Override
+    @Transactional
+    public CartResponseDto createCart(AuthUser authUser, Long storeId ,Long menuId, Integer quantity) {
+
+        User user = userRepository.findById(authUser.getId()).get();
+        Store store = storeRepository.findByIdOrElseThrow(storeId);
+        Menu menu = menuRepository.findByIdOrElseThrow(menuId);
+
+        if (!cartRepository.existsByUserId(authUser.getId())){
+            Cart cart = new Cart(user, store, 0);
+            cartRepository.save(cart);
+        }
+
+        Cart cart = cartRepository.findByUser(user);
+
+        cart.setTotalPrice(menu.getPrice(), quantity);
+
+        CartItem cartItem = new CartItem(cart, menu, quantity, menu.getPrice());
+        cartItemRepository.save(cartItem);
+
+        return new CartResponseDto("장바구니에 추가되었습니다");
+    }
 }

--- a/src/main/java/com/example/toanyone/domain/order/service/OrderServiceImpl.java
+++ b/src/main/java/com/example/toanyone/domain/order/service/OrderServiceImpl.java
@@ -21,7 +21,6 @@ import java.util.List;
   - 주문 생성
   - 주문 항목(OrderItem) 저장
   - 장바구니 초기화 등
-*/
 
 @Service
 @RequiredArgsConstructor
@@ -32,7 +31,7 @@ public class OrderServiceImpl implements OrderService {
     private final OrderItemRepository orderItemRepository;
     private final CartService cartService;
 
-    /*
+
      주문 생성 메서드
      - 고객이 장바구니(cartId)를 기반으로 주문을 생성
      - 유효성 검사: 장바구니 존재, 가게 상태, 최소 주문 금액 확인
@@ -42,7 +41,7 @@ public class OrderServiceImpl implements OrderService {
      @param user 현재 로그인한 사용자 (주문자)
      @param cartId 주문하고자 하는 장바구니 ID
      @return 주문 생성 결과 DTO
-    */
+
     @Transactional
     @Override
     public OrderDto.CreateResponse createOrder(User user, Long cartId) {
@@ -96,3 +95,4 @@ public class OrderServiceImpl implements OrderService {
         );
     }
 }
+*/


### PR DESCRIPTION
 ## 📌 관련 이슈
- Closes #51 

## ✨ 변경 사항
- 장바구니에 메뉴 담기
- StoreId 추가
- Cart와 User 연관관계 OneToOne 
- Cart & CartItem 연관관계 OneToMany 
➡️ 하나의 카트에 여러개의 아이템이 매칭될 수 있다

```java
    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
    private List<CartItem> cartItems = new ArrayList<>();
```
→ Cart에서 CartItem을 리스트로 조회할 수 있게 매핑

## 📷 Postman 
### Postman
<img width="576" alt="image" src="https://github.com/user-attachments/assets/0445c01d-d559-4479-aca0-f8cfaddc18d9" />

### 1. Cart DB
<img width="1382" alt="image" src="https://github.com/user-attachments/assets/5ac4527e-61d5-416d-9231-bde93cdd586e" />
-> 누구의 장바구니인지(user_id) 어떤 가게의 메뉴인지(store_id)

### 2. CartItem DB
<img width="1386" alt="image" src="https://github.com/user-attachments/assets/fa6fd3dd-0471-4d7e-bf33-d23ac8ca2546" />
->  어디 Cart 소속인지(cart_id), 어떤 메뉴에 대한 내용인지(menu_id) 


## ✅ 체크리스트
- [x] 관련 이슈에 연결됨
- [ ] 기능이 정상적으로 동작함
- [ ] 코드 리뷰를 받았음
- [ ] 불필요한 로그/코드 제거됨

## 💬 기타 참고 사항
ApiResponse는 다음 이슈에서 처리할 예정
