### PR TITLE
test : menuCreate 메서드 테스트

### DIFF
--- a/src/main/java/com/example/toanyone/domain/cart/repository/CartRepository.java
+++ b/src/main/java/com/example/toanyone/domain/cart/repository/CartRepository.java
@@ -18,6 +18,6 @@ public interface CartRepository extends JpaRepository<Cart, Long> {
     @Query("SELECT c FROM Cart c WHERE c.user.id = :userId")
     Optional<Cart> findByUserId(@Param("userId") Long userId);
     default Cart findByUserIdOrElseThrow(Long userId) {
-        return findByUserId(userId).orElseThrow(()-> new ApiException(ErrorStatus.USER_NOT_FOUND));
+        return findByUserId(userId).orElseThrow(()-> new ApiException(ErrorStatus.CART_NOT_FOUND));
     }
 }

--- a/src/main/java/com/example/toanyone/global/common/code/ErrorStatus.java
+++ b/src/main/java/com/example/toanyone/global/common/code/ErrorStatus.java
@@ -47,6 +47,7 @@ public enum ErrorStatus implements BaseErrorCode {
     //7000 : cart 에러코드
     CART_ITEMS_NOT_FOUND(HttpStatus.NOT_FOUND, "7001", "장바구니에서 해당 품목을 찾을 수 없습니다."),
     CART_ITEM_QUANTITY_UNDERFLOW(HttpStatus.BAD_REQUEST, "7002", "차감하려는 수량이 담긴 수량보다 많습니다."),
+    CART_NOT_FOUND(HttpStatus.NOT_FOUND, "7003", "사용자의 장바구니를 찾을 수 없습니다"),
 
     ;
 

--- a/src/test/java/com/example/toanyone/domain/menu/service/MenuServiceTest.java
+++ b/src/test/java/com/example/toanyone/domain/menu/service/MenuServiceTest.java
@@ -76,7 +76,22 @@ public class MenuServiceTest {
 
     @Test
     void 이미_있는_메뉴는_추가할_수_없다(){
+        Long storeId = 1L;
+        Long ownerId = 1L;
+        AuthUser authUser = new AuthUser(1L, "kkk@gmail.com", UserRole.OWNER);
+        Store store = new Store();
 
+        //given
+        given(storeRepository.findByIdOrElseThrow(storeId)).willReturn(store);
+        given(storeRepository.findOwnerIdByStoreIdOrElseThrow(storeId)).willReturn(ownerId);
+        given(menuRepository.existsByStoreAndName(store, "menu")).willReturn(true);
+
+        //when
+        ApiException apiException = assertThrows(ApiException.class,
+                ()-> menuService.createMenu(authUser, storeId,"menu", "description", 1000, MainCategory.KOREAN, SubCategory.DRINK));
+
+        //then
+        assertEquals("이미 존재하는 메뉴입니다.", apiException.getMessage());
     }
 
 }

--- a/src/test/java/com/example/toanyone/domain/menu/service/MenuServiceTest.java
+++ b/src/test/java/com/example/toanyone/domain/menu/service/MenuServiceTest.java
@@ -1,0 +1,57 @@
+package com.example.toanyone.domain.menu.service;
+
+import com.example.toanyone.domain.menu.dto.MenuDto;
+import com.example.toanyone.domain.menu.entity.Menu;
+import com.example.toanyone.domain.menu.enums.MainCategory;
+import com.example.toanyone.domain.menu.enums.SubCategory;
+import com.example.toanyone.domain.menu.repository.MenuRepository;
+import com.example.toanyone.domain.store.dto.StoreRequestDto;
+import com.example.toanyone.domain.store.entity.Store;
+import com.example.toanyone.domain.store.repository.StoreRepository;
+import com.example.toanyone.domain.store.service.StoreService;
+import com.example.toanyone.domain.user.enums.UserRole;
+import com.example.toanyone.global.auth.dto.AuthUser;
+import com.example.toanyone.global.common.error.ApiException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class MenuServiceTest {
+    @Mock
+    private StoreRepository storeRepository;
+    @Mock
+    private MenuRepository menuRepository;
+    @InjectMocks
+    private MenuServiceImpl menuService;
+
+
+
+
+    @Test
+    void 가게_주인이_메뉴_생성을_정상적으로_하면_성공한다() {
+        Long storeId = 1L;
+        Long ownerId = 1L;
+        AuthUser authUser = new AuthUser(1L, "kkk@gmail.com", UserRole.OWNER);
+
+        Store store = new Store();
+
+        // given
+        given(storeRepository.findByIdOrElseThrow(storeId)).willReturn(store);
+        given(storeRepository.findOwnerIdByStoreIdOrElseThrow(storeId)).willReturn(ownerId);
+
+        // when
+        MenuDto.Response response = menuService.createMenu(authUser, storeId,
+                "menu", "description", 1000, MainCategory.KOREAN, SubCategory.DRINK);
+
+        // then
+        assertEquals("메뉴 생성되었습니다", response.getMessage());
+    }
+
+}

--- a/src/test/java/com/example/toanyone/domain/menu/service/MenuServiceTest.java
+++ b/src/test/java/com/example/toanyone/domain/menu/service/MenuServiceTest.java
@@ -1,5 +1,6 @@
 package com.example.toanyone.domain.menu.service;
 
+import com.example.toanyone.domain.menu.controller.MenuController;
 import com.example.toanyone.domain.menu.dto.MenuDto;
 import com.example.toanyone.domain.menu.entity.Menu;
 import com.example.toanyone.domain.menu.enums.MainCategory;
@@ -52,6 +53,30 @@ public class MenuServiceTest {
 
         // then
         assertEquals("메뉴 생성되었습니다", response.getMessage());
+    }
+
+
+    @Test
+    void 가게_주인이_아니면_생성을_못한다(){
+        Long storeId = 1L;
+        Long ownerId = 1L;
+        Long anotherOwnerId = 2L;
+
+        AuthUser authUser = new AuthUser(anotherOwnerId, "kkk@gmail.com", UserRole.OWNER);
+        Store store = new Store();
+
+        given(storeRepository.findByIdOrElseThrow(storeId)).willReturn(store);
+        given(storeRepository.findOwnerIdByStoreIdOrElseThrow(storeId)).willReturn(ownerId);
+
+        ApiException apiException = assertThrows(ApiException.class,
+                () -> menuService.createMenu(authUser, storeId,"menu", "description", 1000, MainCategory.KOREAN, SubCategory.DRINK));
+
+        assertEquals("가게의 주인이 아니면 접근할 수 없습니다", apiException.getMessage());
+    }
+
+    @Test
+    void 이미_있는_메뉴는_추가할_수_없다(){
+
     }
 
 }


### PR DESCRIPTION
 ## 📌 관련 이슈
- Closes #97 

## ✨ 변경 사항
### 1️⃣ `MenuService` → `createMenu` 메서드 테스트 수행
1. **정상적으로 메뉴를 추가할 수 있을때** (가게_주인이_메뉴_생성을_정상적으로_하면_성공한다)
2. **본인 가게가 아닐때 실패** (가게_주인이_아니면_생성을_못한다)
3. **이미 있는 메뉴는 추가할 수 없다** (이미_있는_메뉴는_추가할_수_없다)

### 2️⃣ Cart 에러코드 추가 (Cart를 찾을 수 없을 때)

## 📷 Postman 
1️⃣ `MenuService` → `createMenu` 메서드 테스트 수행
<img width="600" alt="image" src="https://github.com/user-attachments/assets/3d7b9024-3c5c-4385-8c3b-89c26238e5d6" />

**코드 내에서 왼쪽 초록색으로 막대기 색이 바뀐것을 확인 가능 & 테스트 커버리지 %**
<img width="1380" alt="image" src="https://github.com/user-attachments/assets/d0dbbe9e-3f1f-4e5a-a37f-b5311a600543" />

### 2️⃣ Cart 에러코드 추가 (Cart를 찾을 수 없을 때)


## ✅ 체크리스트
- [x] 관련 이슈에 연결됨
- [x] 기능이 정상적으로 동작함
- [ ] 코드 리뷰를 받았음
- [ ] 불필요한 로그/코드 제거됨

## 💬 기타 참고 사항
- 테스트 방법, 추가 설명 등 필요한 경우 작성해 주세요.
