### PR TITLE
test: 가게 조회 테스트코드

### DIFF
--- a/src/test/java/com/example/toanyone/domain/store/service/GetStoreByOwner.java
+++ b/src/test/java/com/example/toanyone/domain/store/service/GetStoreByOwner.java
@@ -1,0 +1,73 @@
+package com.example.toanyone.domain.store.service;
+
+import com.example.toanyone.domain.store.dto.StoreRequestDto;
+import com.example.toanyone.domain.store.dto.StoreResponseDto;
+import com.example.toanyone.domain.store.entity.Store;
+import com.example.toanyone.domain.store.enums.Status;
+import com.example.toanyone.domain.store.repository.StoreRepository;
+import com.example.toanyone.domain.user.entity.User;
+import com.example.toanyone.domain.user.enums.UserRole;
+import com.example.toanyone.domain.user.repository.UserRepository;
+import com.example.toanyone.global.auth.dto.AuthUser;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(SpringExtension.class)
+public class GetStoreByOwner {
+    @Mock
+    private StoreRepository storeRepository;
+    @Mock
+    private UserRepository userRepository;
+    @InjectMocks
+    private StoreServiceImpl storeService;
+
+    @Test
+    void 내가_운영중인가게를_조회한다() {
+        Long ownerId = 1L;
+        AuthUser authUser = new AuthUser(ownerId, "eee@gmail.com", UserRole.OWNER);
+
+        User user = new User();
+        ReflectionTestUtils.setField(user, "id", 1L);
+        ReflectionTestUtils.setField(user, "email", "eee@gmail.com");
+        ReflectionTestUtils.setField(user, "userRole", UserRole.OWNER);
+
+        Store store1 = new Store();
+        ReflectionTestUtils.setField(store1, "user", user);
+        ReflectionTestUtils.setField(store1, "id", 1L);
+        ReflectionTestUtils.setField(store1, "name", "가게1");
+
+        Store store2 = new Store();
+        ReflectionTestUtils.setField(store2, "user", user);
+        ReflectionTestUtils.setField(store2, "id", 2L);
+        ReflectionTestUtils.setField(store2, "name", "가게2");
+
+        List<Store> stores = List.of(store1, store2);
+
+        // GIVEN
+        given(userRepository.findById(ownerId)).willReturn(Optional.of(user));
+        given(storeRepository.countByUserIdAndDeletedFalse(1L)).willReturn(2);
+        given(storeRepository.findByUserIdAndDeletedFalse(1L)).willReturn(stores);
+
+        // WHEN
+        List<StoreResponseDto.GetAll> response = storeService.getStoresByOwner(ownerId);
+
+        // THEN
+        assertEquals(2, response.size());
+        assertEquals(store1.getId(), response.get(0).getStoreId());
+        assertEquals(store1.getName(), response.get(0).getName());
+        assertEquals(store2.getId(), response.get(1).getStoreId());
+        assertEquals(store2.getName(), response.get(1).getName());
+
+    }
+}

--- a/src/test/java/com/example/toanyone/domain/store/service/GetStoreByOwner.java
+++ b/src/test/java/com/example/toanyone/domain/store/service/GetStoreByOwner.java
@@ -1,9 +1,7 @@
 package com.example.toanyone.domain.store.service;
 
-import com.example.toanyone.domain.store.dto.StoreRequestDto;
 import com.example.toanyone.domain.store.dto.StoreResponseDto;
 import com.example.toanyone.domain.store.entity.Store;
-import com.example.toanyone.domain.store.enums.Status;
 import com.example.toanyone.domain.store.repository.StoreRepository;
 import com.example.toanyone.domain.user.entity.User;
 import com.example.toanyone.domain.user.enums.UserRole;
@@ -17,7 +15,6 @@ import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 

--- a/src/test/java/com/example/toanyone/domain/store/service/GetStoreByOwner.java
+++ b/src/test/java/com/example/toanyone/domain/store/service/GetStoreByOwner.java
@@ -9,6 +9,7 @@ import com.example.toanyone.domain.user.entity.User;
 import com.example.toanyone.domain.user.enums.UserRole;
 import com.example.toanyone.domain.user.repository.UserRepository;
 import com.example.toanyone.global.auth.dto.AuthUser;
+import com.example.toanyone.global.common.error.ApiException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -21,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(SpringExtension.class)
@@ -70,4 +72,30 @@ public class GetStoreByOwner {
         assertEquals(store2.getName(), response.get(1).getName());
 
     }
+
+    @Test
+    void 내가_운영중인가게가_0개일경우() {
+        Long ownerId = 1L;
+        AuthUser authUser = new AuthUser(ownerId, "eee@gmail.com", UserRole.OWNER);
+
+        User user = new User();
+        ReflectionTestUtils.setField(user, "id", 1L);
+        ReflectionTestUtils.setField(user, "email", "eee@gmail.com");
+        ReflectionTestUtils.setField(user, "userRole", UserRole.OWNER);
+
+        // GIVEN
+        given(userRepository.findById(ownerId)).willReturn(Optional.of(user));
+        given(storeRepository.countByUserIdAndDeletedFalse(1L)).willReturn(0);
+        given(storeRepository.findByUserIdAndDeletedFalse(1L)).willReturn(null);
+
+        // WHEN
+        ApiException apiException = assertThrows(ApiException.class,
+                () -> storeService.getStoresByOwner(ownerId));
+
+        // THEN
+        assertEquals("생성된 가게가 없습니다.",apiException.getMessage());
+
+    }
+
+
 }

--- a/src/test/java/com/example/toanyone/domain/store/service/GetStoreTest.java
+++ b/src/test/java/com/example/toanyone/domain/store/service/GetStoreTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(SpringExtension.class)
-public class GetStoreByOwner {
+public class GetStoreTest {
     @Mock
     private StoreRepository storeRepository;
     @Mock
@@ -91,6 +91,40 @@ public class GetStoreByOwner {
 
         // THEN
         assertEquals("생성된 가게가 없습니다.",apiException.getMessage());
+
+    }
+
+    @Test
+    void 가게명_키워드로_검색() {
+        Store store1 = new Store();
+        ReflectionTestUtils.setField(store1, "id", 1L);
+        ReflectionTestUtils.setField(store1, "name", "치킨1");
+
+        Store store2 = new Store();
+        ReflectionTestUtils.setField(store2, "id", 2L);
+        ReflectionTestUtils.setField(store2, "name", "피자2");
+
+        Store store3 = new Store();
+        ReflectionTestUtils.setField(store3, "id", 3L);
+        ReflectionTestUtils.setField(store3, "name", "치킨3");
+
+        List<Store> stores = List.of(store1, store3);
+
+        String keyword = "치킨";
+
+        // GIVEN
+        given(storeRepository.findByNameContainingAndDeletedFalse(keyword)).willReturn(stores);
+
+
+        // WHEN
+        List<StoreResponseDto.GetAll> response = storeService.getStoresByName(keyword);
+
+        // THEN
+        assertEquals(2, response.size());
+        assertEquals(store1.getId(), response.get(0).getStoreId());
+        assertEquals(store1.getName(), response.get(0).getName());
+        assertEquals(store3.getId(), response.get(1).getStoreId());
+        assertEquals(store3.getName(), response.get(1).getName());
 
     }
 

--- a/src/test/java/com/example/toanyone/domain/store/service/GetStoreTest.java
+++ b/src/test/java/com/example/toanyone/domain/store/service/GetStoreTest.java
@@ -7,6 +7,7 @@ import com.example.toanyone.domain.user.entity.User;
 import com.example.toanyone.domain.user.enums.UserRole;
 import com.example.toanyone.domain.user.repository.UserRepository;
 import com.example.toanyone.global.auth.dto.AuthUser;
+import com.example.toanyone.global.common.code.ErrorStatus;
 import com.example.toanyone.global.common.error.ApiException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -90,7 +91,7 @@ public class GetStoreTest {
                 () -> storeService.getStoresByOwner(ownerId));
 
         // THEN
-        assertEquals("생성된 가게가 없습니다.",apiException.getMessage());
+        assertEquals(ErrorStatus.STORE_NOT_FOUND.getMessage(),apiException.getMessage());
 
     }
 
@@ -150,7 +151,7 @@ public class GetStoreTest {
                 () -> storeService.getStoresByName(keyword));
 
         // THEN
-        assertEquals("검색한 단어가 포함된 가게명이 존재하지 않습니다.", apiException.getMessage());
+        assertEquals(ErrorStatus.STORE_SEARCH_NO_MATCH.getMessage(), apiException.getMessage());
 
     }
 

--- a/src/test/java/com/example/toanyone/domain/store/service/GetStoreTest.java
+++ b/src/test/java/com/example/toanyone/domain/store/service/GetStoreTest.java
@@ -1,5 +1,8 @@
 package com.example.toanyone.domain.store.service;
 
+import com.example.toanyone.domain.menu.entity.Menu;
+import com.example.toanyone.domain.menu.enums.MainCategory;
+import com.example.toanyone.domain.menu.enums.SubCategory;
 import com.example.toanyone.domain.store.dto.StoreRequestDto;
 import com.example.toanyone.domain.store.dto.StoreResponseDto;
 import com.example.toanyone.domain.store.entity.Store;
@@ -179,7 +182,15 @@ public class GetStoreTest {
         LocalTime closeTime = LocalTime.parse("18:00");
 
         Store store = new Store(user, requestDto, Status.OPEN,openTime, closeTime);
+        Menu menu1 = new Menu(store, "메뉴1", "소개1", 5000, MainCategory.KOREAN, SubCategory.MAIN);
+        ReflectionTestUtils.setField(menu1, "id", 1L);
+        Menu menu2 = new Menu(store, "메뉴2", "소개2", 5000, MainCategory.CHINESE, SubCategory.SIDE);
+        ReflectionTestUtils.setField(menu2, "id", 2L);
+
+        List<Menu> menus = List.of(menu1, menu2);
+
         ReflectionTestUtils.setField(store, "id", 1L);
+        ReflectionTestUtils.setField(store, "menus", menus);
 
         // GIVEN
         given(storeRepository.findByIdOrElseThrow(1L)).willReturn(store);
@@ -200,26 +211,20 @@ public class GetStoreTest {
             softly.assertThat(response.getNotice()).isEqualTo("가게공지");
             softly.assertThat(response.getStatus()).isEqualTo(Status.OPEN);
             softly.assertThat(response.getPhone()).isEqualTo("02-123-4567");
+            softly.assertThat(response.getMenus().get(0).getMenuId()).isEqualTo(1L);
+            softly.assertThat(response.getMenus().get(0).getMenuName()).isEqualTo("메뉴1");
+            softly.assertThat(response.getMenus().get(0).getPrice()).isEqualTo(5000);
+            softly.assertThat(response.getMenus().get(0).getDescription()).isEqualTo("소개1");
+            softly.assertThat(response.getMenus().get(0).getMainCategory()).isEqualTo(MainCategory.KOREAN);
+            softly.assertThat(response.getMenus().get(0).getSubCategory()).isEqualTo(SubCategory.MAIN);
+            softly.assertThat(response.getMenus().get(1).getMenuId()).isEqualTo(2L);
+            softly.assertThat(response.getMenus().get(1).getMenuName()).isEqualTo("메뉴2");
+            softly.assertThat(response.getMenus().get(1).getPrice()).isEqualTo(5000);
+            softly.assertThat(response.getMenus().get(1).getDescription()).isEqualTo("소개2");
+            softly.assertThat(response.getMenus().get(1).getMainCategory()).isEqualTo(MainCategory.CHINESE);
+            softly.assertThat(response.getMenus().get(1).getSubCategory()).isEqualTo(SubCategory.SIDE);
 
         });
-
-//        // given
-//        StoreResponseDto.GetById response = storeService.getStoreById(1L);
-//
-//        // then
-//        assertSoftly(softly -> {
-//            softly.assertThat(response.getStoreId()).isEqualTo(1L);
-//            softly.assertThat(response.getOwnerId()).isEqualTo(1L);
-//            softly.assertThat(response.getName()).isEqualTo("가게명");
-//            softly.assertThat(response.getAddress()).isEqualTo("가게주소");
-//            softly.assertThat(response.getOpenTime()).isEqualTo(LocalTime.parse("10:00"));
-//            softly.assertThat(response.getCloseTime()).isEqualTo(LocalTime.parse("18:00"));
-//            softly.assertThat(response.getDeliveryFee()).isEqualTo(3000);
-//            softly.assertThat(response.getMinOrderPrice()).isEqualTo(10000);
-//            softly.assertThat(response.getNotice()).isEqualTo("가게공지");
-//            softly.assertThat(response.getStatus()).isEqualTo(Status.OPEN);
-//            softly.assertThat(response.getPhone()).isEqualTo("02-123-4567");
-//        });
 
     }
 

--- a/src/test/java/com/example/toanyone/domain/store/service/GetStoreTest.java
+++ b/src/test/java/com/example/toanyone/domain/store/service/GetStoreTest.java
@@ -71,7 +71,7 @@ public class GetStoreTest {
     }
 
     @Test
-    void 내가_운영중인가게가_0개일경우() {
+    void 내가_운영중인가게가_없다() {
         Long ownerId = 1L;
         AuthUser authUser = new AuthUser(ownerId, "eee@gmail.com", UserRole.OWNER);
 
@@ -95,7 +95,41 @@ public class GetStoreTest {
     }
 
     @Test
-    void 가게명_키워드로_검색() {
+    void 키워드가_포함된_가게목록을_조회한다() {
+        Store store1 = new Store();
+        ReflectionTestUtils.setField(store1, "id", 1L);
+        ReflectionTestUtils.setField(store1, "name", "치킨1");
+
+        Store store2 = new Store();
+        ReflectionTestUtils.setField(store2, "id", 2L);
+        ReflectionTestUtils.setField(store2, "name", "피자2");
+
+        Store store3 = new Store();
+        ReflectionTestUtils.setField(store3, "id", 3L);
+        ReflectionTestUtils.setField(store3, "name", "치킨3");
+
+        List<Store> stores = List.of(store1, store3);
+
+        String keyword = "치킨";
+
+        // GIVEN
+        given(storeRepository.findByNameContainingAndDeletedFalse(keyword)).willReturn(stores);
+
+
+        // WHEN
+        List<StoreResponseDto.GetAll> response = storeService.getStoresByName(keyword);
+
+        // THEN
+        assertEquals(2, response.size());
+        assertEquals(store1.getId(), response.get(0).getStoreId());
+        assertEquals(store1.getName(), response.get(0).getName());
+        assertEquals(store3.getId(), response.get(1).getStoreId());
+        assertEquals(store3.getName(), response.get(1).getName());
+
+    }
+
+    @Test
+    void 키워드가_포함된_가게명이_없다() {
         Store store1 = new Store();
         ReflectionTestUtils.setField(store1, "id", 1L);
         ReflectionTestUtils.setField(store1, "name", "치킨1");

--- a/src/test/java/com/example/toanyone/domain/store/service/GetStoreTest.java
+++ b/src/test/java/com/example/toanyone/domain/store/service/GetStoreTest.java
@@ -228,4 +228,24 @@ public class GetStoreTest {
 
     }
 
+    @Test
+    void 조회한_가게가_폐업했다() {
+        User user = new User();
+        ReflectionTestUtils.setField(user, "id", 1L);
+
+        Store store = new Store();
+        ReflectionTestUtils.setField(store, "id", 1L);
+        ReflectionTestUtils.setField(store, "deleted", true);
+
+        // GIVEN
+        given(storeRepository.findByIdOrElseThrow(1L)).willReturn(store);
+
+        // WHEN
+        ApiException apiException = assertThrows(ApiException.class,
+                () ->storeService.getStoreById(1L));
+
+        // THEN
+        assertEquals(ErrorStatus.STORE_SHUT_DOWN.getMessage(), apiException.getMessage());
+    }
+
 }

--- a/src/test/java/com/example/toanyone/domain/store/service/GetStoreTest.java
+++ b/src/test/java/com/example/toanyone/domain/store/service/GetStoreTest.java
@@ -98,15 +98,15 @@ public class GetStoreTest {
     void 키워드가_포함된_가게목록을_조회한다() {
         Store store1 = new Store();
         ReflectionTestUtils.setField(store1, "id", 1L);
-        ReflectionTestUtils.setField(store1, "name", "치킨1");
+        ReflectionTestUtils.setField(store1, "name", "치킨가게1");
 
         Store store2 = new Store();
         ReflectionTestUtils.setField(store2, "id", 2L);
-        ReflectionTestUtils.setField(store2, "name", "피자2");
+        ReflectionTestUtils.setField(store2, "name", "피자가게2");
 
         Store store3 = new Store();
         ReflectionTestUtils.setField(store3, "id", 3L);
-        ReflectionTestUtils.setField(store3, "name", "치킨3");
+        ReflectionTestUtils.setField(store3, "name", "치킨가게3");
 
         List<Store> stores = List.of(store1, store3);
 
@@ -132,35 +132,26 @@ public class GetStoreTest {
     void 키워드가_포함된_가게명이_없다() {
         Store store1 = new Store();
         ReflectionTestUtils.setField(store1, "id", 1L);
-        ReflectionTestUtils.setField(store1, "name", "치킨1");
+        ReflectionTestUtils.setField(store1, "name", "치킨가게");
 
         Store store2 = new Store();
         ReflectionTestUtils.setField(store2, "id", 2L);
-        ReflectionTestUtils.setField(store2, "name", "피자2");
+        ReflectionTestUtils.setField(store2, "name", "피자가게");
 
-        Store store3 = new Store();
-        ReflectionTestUtils.setField(store3, "id", 3L);
-        ReflectionTestUtils.setField(store3, "name", "치킨3");
+        List<Store> stores = List.of();
 
-        List<Store> stores = List.of(store1, store3);
-
-        String keyword = "치킨";
+        String keyword = "김밥";
 
         // GIVEN
         given(storeRepository.findByNameContainingAndDeletedFalse(keyword)).willReturn(stores);
 
-
         // WHEN
-        List<StoreResponseDto.GetAll> response = storeService.getStoresByName(keyword);
+        ApiException apiException = assertThrows(ApiException.class,
+                () -> storeService.getStoresByName(keyword));
 
         // THEN
-        assertEquals(2, response.size());
-        assertEquals(store1.getId(), response.get(0).getStoreId());
-        assertEquals(store1.getName(), response.get(0).getName());
-        assertEquals(store3.getId(), response.get(1).getStoreId());
-        assertEquals(store3.getName(), response.get(1).getName());
+        assertEquals("검색한 단어가 포함된 가게명이 존재하지 않습니다.", apiException.getMessage());
 
     }
-
 
 }

--- a/src/test/java/com/example/toanyone/domain/store/service/GetStoreTest.java
+++ b/src/test/java/com/example/toanyone/domain/store/service/GetStoreTest.java
@@ -1,7 +1,9 @@
 package com.example.toanyone.domain.store.service;
 
+import com.example.toanyone.domain.store.dto.StoreRequestDto;
 import com.example.toanyone.domain.store.dto.StoreResponseDto;
 import com.example.toanyone.domain.store.entity.Store;
+import com.example.toanyone.domain.store.enums.Status;
 import com.example.toanyone.domain.store.repository.StoreRepository;
 import com.example.toanyone.domain.user.entity.User;
 import com.example.toanyone.domain.user.enums.UserRole;
@@ -16,9 +18,11 @@ import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
@@ -116,7 +120,6 @@ public class GetStoreTest {
         // GIVEN
         given(storeRepository.findByNameContainingAndDeletedFalse(keyword)).willReturn(stores);
 
-
         // WHEN
         List<StoreResponseDto.GetAll> response = storeService.getStoresByName(keyword);
 
@@ -152,6 +155,71 @@ public class GetStoreTest {
 
         // THEN
         assertEquals(ErrorStatus.STORE_SEARCH_NO_MATCH.getMessage(), apiException.getMessage());
+
+    }
+
+    @Test
+    void 한가게의_정보를_조회한다() {
+        User user = new User();
+        ReflectionTestUtils.setField(user, "id", 1L);
+        
+        StoreRequestDto.Create requestDto = StoreRequestDto.Create.builder()
+                .name("가게명")
+                .address("가게주소")
+                .openTime("10:00")
+                .closeTime("18:00")
+                .deliveryFee(3000)
+                .minOrderPrice(10000)
+                .notice("가게공지")
+                .status("OPEN")
+                .phone("02-123-4567")
+                .build();
+        
+        LocalTime openTime = LocalTime.parse("10:00");
+        LocalTime closeTime = LocalTime.parse("18:00");
+
+        Store store = new Store(user, requestDto, Status.OPEN,openTime, closeTime);
+        ReflectionTestUtils.setField(store, "id", 1L);
+
+        // GIVEN
+        given(storeRepository.findByIdOrElseThrow(1L)).willReturn(store);
+
+        // WHEN
+        StoreResponseDto.GetById response = storeService.getStoreById(1L);
+
+        // THEN
+        assertSoftly(softly -> {
+            softly.assertThat(response.getStoreId()).isEqualTo(1L);
+            softly.assertThat(response.getOwnerId()).isEqualTo(1L);
+            softly.assertThat(response.getName()).isEqualTo("가게명");
+            softly.assertThat(response.getAddress()).isEqualTo("가게주소");
+            softly.assertThat(response.getOpenTime()).isEqualTo(LocalTime.parse("10:00"));
+            softly.assertThat(response.getCloseTime()).isEqualTo(LocalTime.parse("18:00"));
+            softly.assertThat(response.getDeliveryFee()).isEqualTo(3000);
+            softly.assertThat(response.getMinOrderPrice()).isEqualTo(10000);
+            softly.assertThat(response.getNotice()).isEqualTo("가게공지");
+            softly.assertThat(response.getStatus()).isEqualTo(Status.OPEN);
+            softly.assertThat(response.getPhone()).isEqualTo("02-123-4567");
+
+        });
+
+//        // given
+//        StoreResponseDto.GetById response = storeService.getStoreById(1L);
+//
+//        // then
+//        assertSoftly(softly -> {
+//            softly.assertThat(response.getStoreId()).isEqualTo(1L);
+//            softly.assertThat(response.getOwnerId()).isEqualTo(1L);
+//            softly.assertThat(response.getName()).isEqualTo("가게명");
+//            softly.assertThat(response.getAddress()).isEqualTo("가게주소");
+//            softly.assertThat(response.getOpenTime()).isEqualTo(LocalTime.parse("10:00"));
+//            softly.assertThat(response.getCloseTime()).isEqualTo(LocalTime.parse("18:00"));
+//            softly.assertThat(response.getDeliveryFee()).isEqualTo(3000);
+//            softly.assertThat(response.getMinOrderPrice()).isEqualTo(10000);
+//            softly.assertThat(response.getNotice()).isEqualTo("가게공지");
+//            softly.assertThat(response.getStatus()).isEqualTo(Status.OPEN);
+//            softly.assertThat(response.getPhone()).isEqualTo("02-123-4567");
+//        });
 
     }
 


### PR DESCRIPTION
 ## 📌 관련 이슈
- Closes #106

## ✨ 변경 사항
- getStoresByOwner 성공 테스트
- 운영중인 가게가 없을 때 예외 테스트
- getStoresByName 성공 테스트
- 키워드를 포함한 가게가 없을 때 예외 테스트
- 가게 단건 조회 테스트
- 조회한 가게가 폐업된 경우 예외 테스트

## 📷
**- 테스트 성공**
![스크린샷 2025-04-27 130949](https://github.com/user-attachments/assets/f7f68c3b-60a9-4024-8abc-58338bdab416)

**- Code Coverage**
![스크린샷 2025-04-27 130905](https://github.com/user-attachments/assets/275e8c7e-fd6d-4552-b44e-5223dfdae0dc)

**- Coverage Highlight**
- 본인(owner) 가게 조회
![스크린샷 2025-04-27 130919](https://github.com/user-attachments/assets/68001544-9fd4-4fa5-a795-735c5e9d2167)

- 가게 키워드 조회 
![스크린샷 2025-04-27 130925](https://github.com/user-attachments/assets/65987f27-b80f-40da-a8d8-131d2186f14d)

- 가게 단건 조회
![스크린샷 2025-04-27 130931](https://github.com/user-attachments/assets/5be3217f-a466-4a02-bd34-f81145b7c58b)



## ✅ 체크리스트
- [x] 관련 이슈에 연결됨
- [x] 기능이 정상적으로 동작함
- [ ] 코드 리뷰를 받았음
- [ ] 불필요한 로그/코드 제거됨

## 💬 기타 참고 사항
- 테스트 방법, 추가 설명 등 필요한 경우 작성해 주세요.
